### PR TITLE
build: turbo

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
 

--- a/.github/workflows/websub.yml
+++ b/.github/workflows/websub.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ public/robots.txt
 
 # editor
 .obsidian/
+
+# Turbo
+.turbo

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "markdown": "github",
   "scripts": {
-    "dev": "pnpm feed && next dev -H 0.0.0.0",
+    "dev": "pnpm feed && next dev -H 0.0.0.0 --turbo",
     "feed": "node ./lib/feed.mjs",
     "websub": "node ./lib/websub.mjs",
     "start": "next start",
@@ -59,6 +59,6 @@
     "printWidth": 100
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   }
 }

--- a/posts/how.md
+++ b/posts/how.md
@@ -1,6 +1,7 @@
 ---
 title: 这个网站是如何构建的
 date: "2022-08-27"
+modified: "2024-05-04"
 description: 此文用于端到端测试 Markdown 样式
 tags: markdown, example, guide, jamstack, ssg, vercel, nextjs
 ---
@@ -25,6 +26,11 @@ tags: markdown, example, guide, jamstack, ssg, vercel, nextjs
 ```shell
 pnpm install
 pnpm dev
+
+# [Optional] install turbo via `pnpm i -g turbo`
+# and you can try `turbo` for run any script in package.json like:
+turbo dev
+turbo build
 ```
 
 本地访问 <http://localhost:3000> 即可。

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "build": {
+      "outputs": [".next/**", "!.next/cache/**"]
+    },
+    "type-check": {}
+  }
+}


### PR DESCRIPTION
https://areweturboyet.com/

Replacing `next dev` with `turbo dev` will go GA soon (99%). 
but the `next build` currently only has 81% test cases covered. 