### PR TITLE
edge to edge design

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,5 +3,4 @@ node_modules
 .idea
 .obsidian
 .git
-public/atom*
-public/sitemap*
+public/*

--- a/components/bilibili.js
+++ b/components/bilibili.js
@@ -3,7 +3,7 @@ export default function Bilibili({ bv, page, danmaku }) {
     page ? page : 1
   }&danmaku=${danmaku ? danmaku : 0}&high_quality=1`;
   return (
-    <div className="relative w-full overflow-hidden pt-[56.25%] dark:filter dark:dark:brightness-75">
+    <div className="max-w-4xl mx-auto relative w-full overflow-hidden pt-[56.2%] sm:pt-[29.5%] dark:filter dark:dark:brightness-75">
       <iframe
         className="absolute w-full h-full top-0 left-0"
         src={src}

--- a/components/blog.js
+++ b/components/blog.js
@@ -119,10 +119,10 @@ const Blog = props => {
           <div className="social">
             {likes?.length > 0 && (
               <>
-                <h4 id="like">
+                <h6 id="like" className="font-bold my-2">
                   {translations["Likes"]} ({likes?.length})
-                </h4>
-                <div className="mx-2 mt-2 mr-1 flex">
+                </h6>
+                <div className="mt-2 mr-1 flex">
                   {likes?.map(like => {
                     return (
                       <a
@@ -141,13 +141,15 @@ const Blog = props => {
             )}
             {!props.noReply && (
               <>
-                <h4 id="reply">
+                <h6 id="reply" className="font-bold my-2">
                   {translations["Replies from Fediverse"]}
                   {replies?.length > 0 ? `(${replies?.length})` : ""}
-                </h4>
-                <div className="mx-2 mt-4 text-sm">
-                  <span>{translations["Search this URL on Mastodon to reply"]}:</span>
-                  <div className="font-mono my-4 break-words">{pageURL}</div>
+                </h6>
+                <div className="mt-4 text-sm">
+                  <span>
+                    {translations["Search this URL on Mastodon to reply"]}:<code>{pageURL}</code>
+                  </span>
+                  {/* <div className="font-mono my-4 break-words"></div> */}
                   <div className="mt-6">
                     {replies?.map(reply => {
                       return (

--- a/components/blog.js
+++ b/components/blog.js
@@ -110,19 +110,19 @@ const Blog = props => {
       </article>
       {!props.noMeta && (
         <>
-          <div className="mx-2 mt-10">
+          <div className="tags mt-10">
             <div>
               {tags && tags.split(",").map(each => <Tag tag={each} key={each} locale={locale} />)}
             </div>
           </div>
           <hr />
-          <div>
+          <div className="social">
             {likes?.length > 0 && (
               <>
                 <h4 id="like">
                   {translations["Likes"]} ({likes?.length})
                 </h4>
-                <div className="mx-4 mt-2 mr-1 flex">
+                <div className="mx-2 mt-2 mr-1 flex">
                   {likes?.map(like => {
                     return (
                       <a
@@ -145,7 +145,7 @@ const Blog = props => {
                   {translations["Replies from Fediverse"]}
                   {replies?.length > 0 ? `(${replies?.length})` : ""}
                 </h4>
-                <div className="mx-4 mt-4 text-sm">
+                <div className="mx-2 mt-4 text-sm">
                   <span>{translations["Search this URL on Mastodon to reply"]}:</span>
                   <div className="font-mono my-4 break-words">{pageURL}</div>
                   <div className="mt-6">
@@ -176,13 +176,15 @@ const Blog = props => {
               </>
             )}
           </div>
-          {cfg.enableDisqus && !props.noReply && (
-            <Disqus url={pageURL} identifier={id} title={title} />
-          )}
-          {cfg.enableGitHubComment && !props.noReply && <Comments />}
-          {/* {!props.noReward && (
+          <div className="comments">
+            {cfg.enableDisqus && !props.noReply && (
+              <Disqus url={pageURL} identifier={id} title={title} />
+            )}
+            {cfg.enableGitHubComment && !props.noReply && <Comments />}
+            {/* {!props.noReward && (
             <RewardImages text={"Scan the QR Code to leave a tip :)"} />
           )} */}
+          </div>
         </>
       )}
     </Layout>

--- a/components/blog.js
+++ b/components/blog.js
@@ -3,15 +3,14 @@ import Link from "next/link";
 import Layout from "./layout";
 import withView from "./withView";
 import withLocalization from "./withI18n";
-import { useEffect, useState } from "react";
-import "highlight.js/styles/sunburst.css";
-import "gist-syntax-themes/stylesheets/one-dark.css";
+import React, { useEffect, useState } from "react";
 import Tag from "./tag";
 import Avatar from "./avatar";
 import cfg from "../lib/config.mjs";
 import Disqus from "./disqus";
 import Comments from "./comments";
 import mediumZoom from "medium-zoom";
+import { useTheme } from "next-themes";
 
 const Blog = props => {
   const {
@@ -30,6 +29,7 @@ const Blog = props => {
   } = props;
   const [replies, setReplies] = useState([]);
   const [likes, setLikes] = useState([]);
+  const { resolvedTheme } = useTheme();
 
   useEffect(() => {
     mediumZoom(document.querySelectorAll("figure>img"), { background: "rgba(0,0,0,0.3)" });
@@ -49,6 +49,16 @@ const Blog = props => {
 
   return (
     <Layout blog {...props} domain={new URL(pageURL).hostname}>
+      {resolvedTheme && (
+        <link
+          rel="stylesheet"
+          type="text/css"
+          href={resolvedTheme === "light" ? "/css/github.min.css" : "/css/github-dark.min.css"}
+        />
+      )}
+      {resolvedTheme === "dark" && (
+        <link rel="stylesheet" type="text/css" href="/css/terminal.css" />
+      )}
       <article className="blog">
         {!props.noTitle && (
           <h1 id="title" className={`articleTitle text-balance font-medium mb-0 mt-14`}>

--- a/components/comments.js
+++ b/components/comments.js
@@ -19,5 +19,5 @@ export default function Comments() {
     scriptElement.setAttribute("data-input-position", "bottom");
     ref.current?.appendChild(scriptElement);
   }, []);
-  return <div className="mx-2" ref={ref} />;
+  return <div ref={ref} />;
 }

--- a/components/douban.js
+++ b/components/douban.js
@@ -20,8 +20,10 @@ export default function Douban({ id, reverse }) {
   }
 
   return (
-    <div className={`flex h-36 my-4 shadow-lg dark:bg-black ${reverse ? "flex-row-reverse" : ""}`}>
-      <div className="w-2/3 flex flex-col px-4">
+    <div
+      className={`flex h-36 my-4 max-w-4xl mx-auto border dark:bg-black ${reverse ? "flex-row-reverse" : ""}`}
+    >
+      <div className="w-2/3 flex flex-col px-4  ">
         <div className="truncate py-2 flex">
           {movie.title} {movie.original_title}
         </div>

--- a/components/douban.js
+++ b/components/douban.js
@@ -21,7 +21,7 @@ export default function Douban({ id, reverse }) {
 
   return (
     <div
-      className={`flex h-36 my-4 max-w-4xl mx-auto border dark:bg-black ${reverse ? "flex-row-reverse" : ""}`}
+      className={`flex h-36 my-4 max-w-4xl mx-auto border dark:border-none dark:bg-black ${reverse ? "flex-row-reverse" : ""}`}
     >
       <div className="w-2/3 flex flex-col px-4  ">
         <div className="truncate py-2 flex">

--- a/components/github.js
+++ b/components/github.js
@@ -40,9 +40,7 @@ export default function GitHub({ user, repo }) {
           <a href={data.html_url} target="_blank" rel="noopener noreferrer">
             {data.full_name}
           </a>
-          <span className="ml-2 rounded-full border border-zinc-500 text-xs px-1">
-            {data.is_template ? "Public template" : "Public"}
-          </span>
+          <span className="ml-2 rounded-full border border-zinc-500 text-xs px-1">Public</span>
         </p>
         <p className="my-3 text-sm">{data.description}</p>
         <p className="my-3 text-sm">

--- a/components/github.js
+++ b/components/github.js
@@ -31,19 +31,21 @@ export default function GitHub({ user, repo }) {
   }
 
   return (
-    <div className="my-6 flex items-center shadow-md dark:bg-black">
+    <div className="my-4 flex items-center border-t border-b border-zinc-100 dark:border-zinc-800  dark:bg-black">
       <div className="flex-1">
-        <p className="my-2 pl-4">
-          <span className="mr-1">📔</span>
+        <p className="my-2">
+          <span className="mr-1 h-5 w-5">
+            <GitHubIcon style={{ height: 20, width: 20 }} />
+          </span>
           <a href={data.html_url} target="_blank" rel="noopener noreferrer">
-            {data.name}
+            {data.full_name}
           </a>
           <span className="ml-2 rounded-full border border-zinc-500 text-xs px-1">
             {data.is_template ? "Public template" : "Public"}
           </span>
         </p>
         <p className="my-3 text-sm">{data.description}</p>
-        <p className="my-3 text-sm pl-4">
+        <p className="my-3 text-sm">
           {data && (
             <span
               className={`w-3 h-3 inline-block rounded-full mr-1 ${
@@ -56,9 +58,9 @@ export default function GitHub({ user, repo }) {
           <span>🛠 {data.forks}</span>
         </p>
       </div>
-      <div className="w-28 h-24">
+      {/* <div className="w-28 h-24">
         <GitHubIcon style={{ height: 84, width: 84 }} />
-      </div>
+      </div> */}
     </div>
   );
 }

--- a/components/header.js
+++ b/components/header.js
@@ -79,8 +79,8 @@ function Header({
         ))}
         {enableAdsense && <Adsense />}
       </Head>
-      <header className="flex justify-between sticky top-0 mt-10 z-50 backdrop-blur-lg bg-white/50 dark:bg-zinc-900/50 ">
-        <div className="flex justify-between max-w-3xl mx-auto w-full  ">
+      <header className="flex justify-between sticky top-0 mt-10 z-50 backdrop-blur-lg bg-white/50 dark:bg-zinc-900/50">
+        <div className="flex justify-between max-w-3xl mx-auto w-full">
           <h1 className="w-48 cursor-pointer">
             <Link href={"/"}>
               <div className={`py-1 ${hoverTabStyle}`}>
@@ -89,7 +89,7 @@ function Header({
             </Link>
           </h1>
           <div className="flex-1"></div>
-          <nav className="w-48 mt-3 items-center mx-2">
+          <nav className="w-48 mt-3 mx-4 items-center ">
             <ul className="flex">
               {navItems?.map(item => {
                 return (

--- a/components/header.js
+++ b/components/header.js
@@ -6,6 +6,7 @@ import Logo from "./logo";
 import { Adsense } from "./analytics";
 import withLocalization from "./withI18n";
 import LocalizationSwitch from "./switcher";
+import React, { useEffect, useState } from "react";
 
 function Header({
   title,
@@ -45,6 +46,24 @@ function Header({
   });
   const hoverTabStyle =
     "opacity-65 hover:opacity-95 transition duration-500 hover:transition-transform";
+
+  const [isNavbarVisible, setIsNavbarVisible] = useState(true);
+  const [lastScrollTop, setLastScrollTop] = useState(0);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const scrollTop = window.scrollY || document.documentElement.scrollTop;
+      if (scrollTop > lastScrollTop) {
+        setIsNavbarVisible(false);
+      } else {
+        setIsNavbarVisible(true);
+      }
+      setLastScrollTop(scrollTop <= 0 ? 0 : scrollTop);
+    };
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [lastScrollTop]);
+
   return (
     <>
       <Head>
@@ -79,7 +98,9 @@ function Header({
         ))}
         {enableAdsense && <Adsense />}
       </Head>
-      <header className="flex justify-between sticky top-0 mt-10 z-50 backdrop-blur-lg bg-white/50 dark:bg-zinc-900/50">
+      <header
+        className={`${isNavbarVisible ? "translate-y-0" : "-translate-y-full"} sticky-header`}
+      >
         <div className="flex justify-between max-w-3xl mx-auto w-full">
           <h1 className="w-48 cursor-pointer">
             <Link href={"/"}>

--- a/components/header.js
+++ b/components/header.js
@@ -80,15 +80,16 @@ function Header({
         {enableAdsense && <Adsense />}
       </Head>
       <header className="flex justify-between sticky top-0 mt-10 z-50 backdrop-blur-lg bg-white/50 dark:bg-zinc-900/50 ">
-        <div className="w-[48rem] flex justify-between mx-auto ">
-          <h1 className="w-32 cursor-pointer">
+        <div className="flex justify-between max-w-3xl mx-auto w-full  ">
+          <h1 className="w-48 cursor-pointer">
             <Link href={"/"}>
-              <div className={`py-1 -mx-2 ${hoverTabStyle}`}>
+              <div className={`py-1 ${hoverTabStyle}`}>
                 <Logo title={siteTitle} />
               </div>
             </Link>
           </h1>
-          <nav className="flex-4 mt-3 items-center">
+          <div className="flex-1"></div>
+          <nav className="w-48 mt-3 items-center mx-2">
             <ul className="flex">
               {navItems?.map(item => {
                 return (

--- a/components/layout.js
+++ b/components/layout.js
@@ -7,9 +7,9 @@ export default function Layout(props) {
     <>
       <Header {...props} />
       <main
-        className={`mx-auto max-w-3xl prose prose-slate dark:prose-invert prose-pre:rounded-none prose-pre:bg-black
+        className="mx-auto max-w-none prose prose-slate dark:prose-invert prose-pre:rounded-none prose-pre:bg-black
       prose-p:before:content-none prose-headings:[*>a]:no-unnderline prose-blockquote:border-purple-600
-      prose-blockquote:text-purple-600 prose-blockquote:not-italic prose-blockquote:border-l-[2.6px] prose-blockquote:pl-2`}
+      prose-blockquote:text-purple-600 prose-blockquote:not-italic prose-blockquote:border-l-[2.6px] prose-blockquote:pl-2"
       >
         <div>{children}</div>
         {!props.noFooter && <Footer />}

--- a/components/layout.js
+++ b/components/layout.js
@@ -7,7 +7,7 @@ export default function Layout(props) {
     <>
       <Header {...props} />
       <main
-        className="mx-auto max-w-none prose prose-slate dark:prose-invert prose-pre:rounded-none prose-pre:bg-black
+        className="mx-auto max-w-none prose prose-slate dark:prose-invert prose-pre:rounded-none prose-pre:bg-zinc-50 dark:prose-pre:bg-black
       prose-p:before:content-none prose-headings:[*>a]:no-unnderline prose-blockquote:border-purple-600
       prose-blockquote:text-purple-600 prose-blockquote:not-italic prose-blockquote:border-l-[2.6px] prose-blockquote:pl-2"
       >

--- a/components/logo.js
+++ b/components/logo.js
@@ -1,5 +1,5 @@
 const Logo = ({ title }) => (
-  <span className="inline-flex items-center pb-1 ml-2">
+  <span className="inline-flex items-center pb-1">
     <span className="mt-0 text-3xl font-bold">◳</span>
     <span className="pl-2 pt-1">{title}</span>
   </span>

--- a/components/tag.js
+++ b/components/tag.js
@@ -11,7 +11,7 @@ export default function Tag(props) {
       locale={props.locale}
     >
       <span
-        className={`before:content-['#'] duration-100 transition rounded inline-block p-1 mx-1 text-sm font-mono ${highlight}`}
+        className={`before:content-['#'] duration-100 transition rounded inline-block p-1 mr-1 text-sm font-mono ${highlight}`}
       >
         {props.tag.trim()}
       </span>

--- a/pages/about.js
+++ b/pages/about.js
@@ -21,7 +21,7 @@ const About = props => {
           <h3 id="projects">
             <a href="#projects">{translations["Open-Source Projects"]}</a>
           </h3>
-          <div className="flex flex-wrap gap-3">
+          <div className="projects flex flex-wrap gap-3">
             {config.projects.map(project => (
               <Project {...project} key={project.name} locale={locale} />
             ))}

--- a/pages/blog/[id].js
+++ b/pages/blog/[id].js
@@ -28,7 +28,7 @@ const PathId = props => {
   return (
     <Blog {...props}>
       {/* <div dangerouslySetInnerHTML={{ __html: props.htmlStringContent }} /> */}
-      <main>{render(props.htmlAst)}</main>
+      <main className="overflow-visible h-auto">{render(props.htmlAst)}</main>
     </Blog>
   );
 };

--- a/posts/2022-in-review.md
+++ b/posts/2022-in-review.md
@@ -81,5 +81,7 @@ CVA Trading Desk 其实是一家内部保险公司。负责保障 Business Line 
 > 😅
 
 [^1]: [The Role of a CVA Desk - O'Reilly](https://www.oreilly.com/library/view/counterparty-credit-risk/9781118316665/c18anchor-2.html)
+
 [^2]: [Cloudflare Zero Trust](https://www.cloudflare.com/zh-cn/products/zero-trust/)
+
 [^3]: [现状不可描述](https://bit.ly/3V5V1NG)

--- a/posts/2022-in-review.md
+++ b/posts/2022-in-review.md
@@ -81,7 +81,5 @@ CVA Trading Desk 其实是一家内部保险公司。负责保障 Business Line 
 > 😅
 
 [^1]: [The Role of a CVA Desk - O'Reilly](https://www.oreilly.com/library/view/counterparty-credit-risk/9781118316665/c18anchor-2.html)
-
 [^2]: [Cloudflare Zero Trust](https://www.cloudflare.com/zh-cn/products/zero-trust/)
-
 [^3]: [现状不可描述](https://bit.ly/3V5V1NG)

--- a/posts/how.md
+++ b/posts/how.md
@@ -1,9 +1,9 @@
 ---
 title: 这个网站是如何构建的
 date: "2022-08-27"
-modified: "2024-05-04"
+modified: "2024-07-07"
 description: 此文用于端到端测试 Markdown 样式
-tags: markdown, example, guide, jamstack, ssg, vercel, nextjs
+tags: markdown, example, guide, jamstack, ssg, vercel, nextjs, design
 ---
 
 ## 使用方式
@@ -39,6 +39,11 @@ turbo build
 通过 `pnpm fmt` 来将所有代码和文本进行格式化。
 
 这篇文章展示了此博客项目所能展示的一切媒体信息，比如代码引用、表格展示、图片、视频、豆瓣卡片等等。
+
+2024/07 更新：
+
+- 顶部导航栏启用毛玻璃动态悬浮
+- 全新的 edge to edge 设计风格，充分利用屏幕区域展示代码和图片
 
 ## 技术细节
 

--- a/public/css/github-dark.min.css
+++ b/public/css/github-dark.min.css
@@ -1,0 +1,10 @@
+pre code.hljs{display:block;overflow-x:auto;padding:1em}code.hljs{padding:3px 5px}/*!
+  Theme: GitHub Dark
+  Description: Dark theme as seen on github.com
+  Author: github.com
+  Maintainer: @Hirse
+  Updated: 2021-05-15
+
+  Outdated base version: https://github.com/primer/github-syntax-dark
+  Current colors taken from GitHub's CSS
+*/.hljs{color:#c9d1d9;background:#000}.hljs-doctag,.hljs-keyword,.hljs-meta .hljs-keyword,.hljs-template-tag,.hljs-template-variable,.hljs-type,.hljs-variable.language_{color:#ff7b72}.hljs-title,.hljs-title.class_,.hljs-title.class_.inherited__,.hljs-title.function_{color:#d2a8ff}.hljs-attr,.hljs-attribute,.hljs-literal,.hljs-meta,.hljs-number,.hljs-operator,.hljs-selector-attr,.hljs-selector-class,.hljs-selector-id,.hljs-variable{color:#79c0ff}.hljs-meta .hljs-string,.hljs-regexp,.hljs-string{color:#a5d6ff}.hljs-built_in,.hljs-symbol{color:#ffa657}.hljs-code,.hljs-comment,.hljs-formula{color:#8b949e}.hljs-name,.hljs-quote,.hljs-selector-pseudo,.hljs-selector-tag{color:#7ee787}.hljs-subst{color:#c9d1d9}.hljs-section{color:#1f6feb;font-weight:700}.hljs-bullet{color:#f2cc60}.hljs-emphasis{color:#c9d1d9;font-style:italic}.hljs-strong{color:#c9d1d9;font-weight:700}.hljs-addition{color:#aff5b4;background-color:#033a16}.hljs-deletion{color:#ffdcd7;background-color:#67060c}

--- a/public/css/github.min.css
+++ b/public/css/github.min.css
@@ -1,0 +1,10 @@
+pre code.hljs{display:block;overflow-x:auto;padding:1em}code.hljs{padding:3px 5px}/*!
+  Theme: GitHub
+  Description: Light theme as seen on github.com
+  Author: github.com
+  Maintainer: @Hirse
+  Updated: 2021-05-15
+
+  Outdated base version: https://github.com/primer/github-syntax-light
+  Current colors taken from GitHub's CSS
+*/.hljs{color:#24292e;background:#fafafa}.hljs-doctag,.hljs-keyword,.hljs-meta .hljs-keyword,.hljs-template-tag,.hljs-template-variable,.hljs-type,.hljs-variable.language_{color:#d73a49}.hljs-title,.hljs-title.class_,.hljs-title.class_.inherited__,.hljs-title.function_{color:#6f42c1}.hljs-attr,.hljs-attribute,.hljs-literal,.hljs-meta,.hljs-number,.hljs-operator,.hljs-selector-attr,.hljs-selector-class,.hljs-selector-id,.hljs-variable{color:#005cc5}.hljs-meta .hljs-string,.hljs-regexp,.hljs-string{color:#032f62}.hljs-built_in,.hljs-symbol{color:#e36209}.hljs-code,.hljs-comment,.hljs-formula{color:#6a737d}.hljs-name,.hljs-quote,.hljs-selector-pseudo,.hljs-selector-tag{color:#22863a}.hljs-subst{color:#24292e}.hljs-section{color:#005cc5;font-weight:700}.hljs-bullet{color:#735c0f}.hljs-emphasis{color:#24292e;font-style:italic}.hljs-strong{color:#24292e;font-weight:700}.hljs-addition{color:#22863a;background-color:#f0fff4}.hljs-deletion{color:#b31d28;background-color:#ffeef0}

--- a/public/css/terminal.css
+++ b/public/css/terminal.css
@@ -1,0 +1,103 @@
+body .gist .highlight {
+    background: #000;
+}
+body .gist .blob-num,
+body .gist .blob-code-inner,
+body .gist .pl-en,
+body .gist .pl-sc,
+body .gist .highlight-source-css .pl-k,
+body .gist .highlight-source-css .pl-ent {
+    color: #dedede;
+}
+body .gist .pl-c,
+body .gist .pl-c span {
+    color: #ff4500;
+    font-style: italic;
+}
+body .gist .pl-mb {
+    color: #e78c45;
+    font-weight: 700;
+}
+body .gist .pl-mh .pl-en {
+    color: #b9ca4a;
+    font-weight: 700;
+}
+body .gist .pl-mi {
+    color: #ff6347;
+    font-style: italic;
+}
+body .gist .pl-mq {
+    color: #ff4500;
+}
+body .gist .pl-id {
+    color: #ced2cf;
+    background: #b798bf;
+}
+body .gist .pl-ii {
+    color: #ff0;
+    background: red;
+}
+body .gist .highlight-source-js .pl-k {
+    color: #ff1493;
+}
+body .gist .pl-c1,
+body .gist .pl-s1 .pl-pse .pl-s2,
+body .gist .pl-sv,
+body .gist .pl-vpf {
+    color: #e78c45;
+}
+body .gist .pl-e,
+body .gist .pl-s3,
+body .gist .pl-sr,
+body .gist .pl-sr .pl-sra,
+body .gist .pl-sr .pl-sre,
+body .gist .pl-src,
+body .gist .pl-v,
+body .gist .highlight-text-html-basic .pl-ent,
+body .gist .highlight-text-html-php .pl-vo {
+    color: #d54e53;
+}
+body .gist .pl-ent,
+body .gist .pl-k,
+body .gist .pl-mdh,
+body .gist .pl-mdr,
+body .gist .pl-ml,
+body .gist .pl-mm,
+body .gist .pl-mo,
+body .gist .pl-mp,
+body .gist .pl-mr,
+body .gist .pl-ms,
+body .gist .pl-s,
+body .gist .pl-s1 .pl-v,
+body .gist .pl-st {
+    color: #ff6347;
+}
+body .gist .pl-mh,
+body .gist .pl-pds,
+body .gist .pl-s1,
+body .gist .pl-sr .pl-cce {
+    color: #b9ca4a;
+}
+body .gist .pl-s1 .pl-s2,
+body .gist .pl-smi,
+body .gist .pl-smp,
+body .gist .pl-stj,
+body .gist .pl-vo,
+body .gist .highlight-text-html-php .pl-s3,
+body .gist .highlight-source-python .pl-s3 {
+    color: #7aa6da;
+}
+body .gist .pl-mi1,
+body .gist .pl-mdht {
+    color: #dedede;
+    background: rgba(0, 64, 0, .5);
+}
+body .gist .pl-md,
+body .gist .pl-mdhf {
+    color: #dedede;
+    background: red;
+}
+body .gist .highlight-source-css .pl-s3,
+body .gist .highlight-source-css .pl-sc {
+    color: #e7c547;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -53,7 +53,7 @@
   h4,
   h5,
   code {
-    @apply max-w-3xl mx-auto px-2;
+    @apply max-w-3xl mx-auto px-4 break-words;
   }
 
   table,

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -51,9 +51,12 @@
   h2,
   h3,
   h4,
-  h5,
+  h5 {
+    @apply max-w-3xl mx-auto px-4;
+  }
+
   code {
-    @apply max-w-3xl mx-auto px-4 break-words;
+    @apply break-words  max-w-3xl mx-auto;
   }
 
   table,
@@ -68,13 +71,18 @@
     @apply hover:after:content-["#"] hover:after:mx-2 hover:text-gray-400 cursor-pointer;
   }
 
-  /* details {
-    @apply text-sm px-4 py-2 border-t-2 border-b-2 border-dashed border-zinc-200 dark:border-zinc-800;
-  } */
+  .sticky-header {
+    @apply ease-out transition-transform duration-500 flex justify-between sticky 
+   top-0 mt-10 z-50 backdrop-blur-lg bg-white/50 dark:bg-zinc-900/50;
+  }
 
-  /* summary {
+  details {
+    @apply text-sm px-2 py-2 border-t-2 border-b-2 border-dashed border-zinc-200 dark:border-zinc-800;
+  }
+
+  summary {
     @apply cursor-pointer font-semibold;
-  } */
+  }
 }
 
 @tailwind utilities;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -6,8 +6,12 @@
     font-family: -apple-system, system-ui, sans-serif, Roboto, "Noto Sans", "Segoe UI";
   }
 
+  figure {
+    @apply max-w-max w-full mx-auto;
+  }
+
   img {
-    @apply mx-auto dark:filter dark:brightness-75 shadow-lg;
+    @apply mx-auto dark:filter dark:brightness-75;
   }
 
   /* iframe  */
@@ -26,39 +30,35 @@
   }
 
   figcaption {
-    @apply text-center font-mono text-balance;
+    @apply text-center text-balance;
   }
 }
 
 @tailwind components;
 
 @layer components {
-  /* margin all content except media like images */
   .blogIndex,
   .articleTitle,
+  .tags,
+  .social,
+  .comments,
+  .gist,
   p,
   blockquote,
+  ol,
   ul,
   h1,
   h2,
   h3,
   h4,
-  h5 {
-    @apply mx-4;
-  }
-
-  p:has(img),
-  p:has(span),
-  li > p {
-    @apply mx-0;
-  }
-
+  h5,
   code {
-    @apply break-words;
+    @apply max-w-3xl mx-auto px-2;
   }
 
-  details:has(pre) pre {
-    @apply -mx-4;
+  table,
+  .projects {
+    @apply max-w-4xl mx-auto;
   }
 
   h2 > a,
@@ -68,13 +68,13 @@
     @apply hover:after:content-["#"] hover:after:mx-2 hover:text-gray-400 cursor-pointer;
   }
 
-  details {
+  /* details {
     @apply text-sm px-4 py-2 border-t-2 border-b-2 border-dashed border-zinc-200 dark:border-zinc-800;
-  }
+  } */
 
-  summary {
+  /* summary {
     @apply cursor-pointer font-semibold;
-  }
+  } */
 }
 
 @tailwind utilities;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -42,7 +42,6 @@
   .tags,
   .social,
   .comments,
-  .gist,
   p,
   blockquote,
   ol,
@@ -60,8 +59,9 @@
   }
 
   table,
+  .gist,
   .projects {
-    @apply max-w-4xl mx-auto;
+    @apply max-w-3xl mx-auto;
   }
 
   h2 > a,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 增加了 GitHub Dark 主题和 GitHub Light 主题用于代码语法高亮。
  - 新增了用于网页终端界面的 `terminal.css` 样式文件。

- **样式**
  - 调整了多个组件和页面的样式以优化布局和视觉效果，其中包括 `bilibili`、`douban`、`github`、`layout` 等组件。
  - 通过 `useTheme` 钩子动态加载不同的 CSS 文件以支持主题切换。
  - `.prettierignore` 文件更新以排除 `public` 目录中的所有文件。
  - 更新 `global.css` 文件，调整了 `figure`、`img`、`code` 等标签的样式。

- **修复**
  - 修复了导航栏的动态显示/隐藏问题，提升用户体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->