### PR TITLE
activitypub: add nodeinfo

### DIFF
--- a/pages/api/.well-known/nodeinfo.js
+++ b/pages/api/.well-known/nodeinfo.js
@@ -1,0 +1,13 @@
+import { getOrigin } from "../../../lib/util";
+
+export default async function nodeinfo(req, res) {
+  const origin = getOrigin(req);
+  res.json({
+    links: [
+      {
+        rel: "http://nodeinfo.diaspora.software/ns/schema/2.0",
+        href: `${origin}/api/activitypub/nodeinfo`,
+      },
+    ],
+  });
+}

--- a/pages/api/.well-known/nodeinfo.js
+++ b/pages/api/.well-known/nodeinfo.js
@@ -1,13 +1,17 @@
 import { getOrigin } from "../../../lib/util";
 
 export default async function nodeinfo(req, res) {
-  const origin = getOrigin(req);
-  res.json({
-    links: [
-      {
-        rel: "http://nodeinfo.diaspora.software/ns/schema/2.0",
-        href: `${origin}/api/activitypub/nodeinfo`,
-      },
-    ],
-  });
+  try {
+    const origin = getOrigin(req);
+    res.json({
+      links: [
+        {
+          rel: "http://nodeinfo.diaspora.software/ns/schema/2.0",
+          href: `${origin}/api/activitypub/nodeinfo`,
+        },
+      ],
+    });
+  } catch (error) {
+    res.status(500).json({ error: "Internal Server Error" });
+  }
 }

--- a/pages/api/.well-known/security.txt.js
+++ b/pages/api/.well-known/security.txt.js
@@ -1,0 +1,12 @@
+import config from "../../../lib/config.mjs";
+
+export default async function nodeinfo(req, res) {
+  const { github, baseURL } = config;
+  res.end(
+    `Contact: https://hackerone.com/${github}
+Preferred-Languages: zh,en
+Canonical: ${baseURL}/.well-known/security.txt
+Expires: 2070-01-01T00:00:00z
+`,
+  );
+}

--- a/pages/api/activitypub/nodeinfo.js
+++ b/pages/api/activitypub/nodeinfo.js
@@ -1,23 +1,27 @@
 import config from "../../../lib/config.mjs";
 
 export default async function nodeInfo(req, res) {
-  const { siteDescription, baseURL, github, repo } = config;
-  const data = {
-    metadata: {
-      nodeName: "site - lawrenceli.me",
-      nodeDescription: siteDescription,
-      software: {
-        homepage: baseURL,
-        github: `https://github.com/${github}/${repo}`,
-        follow: "https://mstdn.social/@lawrence",
+  try {
+    const { siteDescription, baseURL, github, repo } = config;
+    const data = {
+      metadata: {
+        nodeName: "site - lawrenceli.me",
+        nodeDescription: siteDescription,
+        software: {
+          homepage: baseURL,
+          github: `https://github.com/${github}/${repo}`,
+          follow: "https://mstdn.social/@lawrence`,
+        },
       },
-    },
-    openRegistrations: false,
-    protocols: ["activitypub"],
-    services: { inbound: [], outbound: [] },
-    software: { name: repo, version: "1.0.0" },
-    usage: { users: { total: 1, activeHalfyear: 1, activeMonth: 1 }, localPosts: 20 },
-    version: "2.0",
-  };
-  res.json(data);
+      openRegistrations: false,
+      protocols: ["activitypub"],
+      services: { inbound: [], outbound: [] },
+      software: { name: repo, version: "1.0.0" },
+      usage: { users: { total: 1, activeHalfyear: 1, activeMonth: 1 }, localPosts: 20 },
+      version: "2.0",
+    };
+    res.json(data);
+  } catch (error) {
+    res.status(500).json({ error: "Internal Server Error" });
+  }
 }

--- a/pages/api/activitypub/nodeinfo.js
+++ b/pages/api/activitypub/nodeinfo.js
@@ -10,7 +10,7 @@ export default async function nodeInfo(req, res) {
         software: {
           homepage: baseURL,
           github: `https://github.com/${github}/${repo}`,
-          follow: "https://mstdn.social/@lawrence`,
+          follow: "https://mstdn.social/@lawrence",
         },
       },
       openRegistrations: false,

--- a/pages/api/activitypub/nodeinfo.js
+++ b/pages/api/activitypub/nodeinfo.js
@@ -1,0 +1,23 @@
+import config from "../../../lib/config.mjs";
+
+export default async function nodeInfo(req, res) {
+  const { siteDescription, baseURL, github, repo } = config;
+  const data = {
+    metadata: {
+      nodeName: "site - lawrenceli.me",
+      nodeDescription: siteDescription,
+      software: {
+        homepage: baseURL,
+        github: `https://github.com/${github}/${repo}`,
+        follow: "https://mstdn.social/@lawrence",
+      },
+    },
+    openRegistrations: false,
+    protocols: ["activitypub"],
+    services: { inbound: [], outbound: [] },
+    software: { name: repo, version: "1.0.0" },
+    usage: { users: { total: 1, activeHalfyear: 1, activeMonth: 1 }, localPosts: 20 },
+    version: "2.0",
+  };
+  res.json(data);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
  - 新增 NodeInfo API 端点，支持 ActivityPub 服务，提供节点的元数据和使用统计信息。
  - 实现了一个新的 HTTP 请求处理函数，返回符合 NodeInfo 2.0 规范的 JSON 响应，支持联邦社交网络的互操作性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->