### PR TITLE
feat: play go

### DIFF
--- a/components/katago-board.js
+++ b/components/katago-board.js
@@ -9,7 +9,7 @@ import styles from "./katago-board.module.css";
 
 const API = "https://kata.lawrenceli.me/api/v1/analysis";
 const MAX_VISITS = 50;
-const REQUEST_TIMEOUT = 50000;
+const REQUEST_TIMEOUT = 100000;
 
 // 棋盘 SVG 尺寸（viewBox 单位）
 const M = 34;
@@ -191,7 +191,7 @@ export default function KatagoBoard() {
       }
     } catch (e) {
       if (e.name === "AbortError") return; // 被悔棋/新局取消
-      setError("AI 分析失败（服务繁忙），可重试或让 AI 弃权");
+      setError("AI 分析失败，可重试或让 AI 弃权");
       setPhase("error");
     } finally {
       clearTimeout(timeout);
@@ -301,7 +301,7 @@ export default function KatagoBoard() {
       : "对局结束"
     : phase === "error"
       ? error
-      : `轮到${turn === "B" ? "黑" : "白"}棋${turn === userColor ? "（你）" : ""}`;
+      : `轮到${turn === "B" ? "黑" : "白"}棋`;
 
   const resultText = result
     ? result.via === "resign"
@@ -329,7 +329,7 @@ export default function KatagoBoard() {
       >
         <div className="flex w-16 shrink-0 items-center justify-center">
           {phase === "thinking" && (
-            <span className="flex items-center gap-1" aria-label="AI 思考中">
+            <span className="flex items-center gap-1" aria-label="Thinking">
               <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-zinc-500 dark:bg-zinc-400" />
               <span
                 className="h-1.5 w-1.5 animate-pulse rounded-full bg-zinc-500 dark:bg-zinc-400"
@@ -342,7 +342,7 @@ export default function KatagoBoard() {
             </span>
           )}
         </div>
-        <span className={`w-36 shrink-0 text-center ${hint ? "text-red-500" : ""}`}>
+        <span className={`w-36 shrink-0 text-xs ${hint ? "text-red-500" : ""}`}>
           {hint || statusText}
         </span>
         <div className="w-44 shrink-0 text-center text-xs tabular-nums">
@@ -354,7 +354,7 @@ export default function KatagoBoard() {
       {/* 棋盘 */}
       <div
         className={
-          zen ? "w-full max-w-[min(92vw,92vh)] px-4 sm:px-0" : "relative mx-auto max-w-[720px]"
+          zen ? "w-full max-w-[min(92vw,92vh)] px-4 sm:px-0" : "relative mx-auto max-w-180"
         }
       >
         <svg
@@ -455,10 +455,10 @@ export default function KatagoBoard() {
 
       {/* 分析信息 */}
       {!zen && (analysis || (gameOver && resultText) || phase === "error") && (
-        <div className="mx-auto mt-4 max-w-[720px] text-sm text-zinc-600 dark:text-zinc-400">
+        <div className="mx-auto mt-4 max-w-180 text-sm text-zinc-600 dark:text-zinc-400">
           {analysis ? (
             <div className="flex flex-col gap-1.5 text-xs tabular-nums">
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2 mx-1">
                 <span className="w-7 shrink-0">AI</span>
                 <div className="h-2 flex-1 overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-800">
                   <div
@@ -513,7 +513,7 @@ export default function KatagoBoard() {
         className={
           zen
             ? "hidden"
-            : "mx-auto mt-4 flex max-w-[720px] flex-wrap items-center justify-center gap-2 text-xs"
+            : "mx-auto mt-4 flex max-w-180 flex-wrap items-center justify-center gap-2 text-xs"
         }
       >
         {/* 执黑 / 执白 */}

--- a/components/katago-board.js
+++ b/components/katago-board.js
@@ -1,0 +1,593 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { N, coordToXY, xyToCoord, buildState, isLegal } from "../lib/go-rules";
+import styles from "./katago-board.module.css";
+
+/**
+ * 19x19 围棋对弈棋盘，与 katago-server (https://kata.lawrenceli.me) 实时对弈。
+ * 棋局状态完全在浏览器端维护，每次分析仅提交完整落子序列（无状态分析接口）。
+ */
+
+const API = "https://kata.lawrenceli.me/api/v1/analysis";
+const MAX_VISITS = 50;
+const REQUEST_TIMEOUT = 50000;
+
+// 棋盘 SVG 尺寸（viewBox 单位）
+const M = 34;
+const S = 620;
+const CELL = (S - M * 2) / (N - 1);
+const STAR = [3, 9, 15];
+
+const pct = v => (v == null ? "—" : `${Math.round(v * 1000) / 10}%`);
+
+/** 数值变化时以 ease-out 缓动插值（用于胜率计数动画） */
+function useAnimatedValue(value, duration = 700) {
+  const [display, setDisplay] = useState(value);
+  const prevRef = useRef(value);
+  useEffect(() => {
+    const from = prevRef.current;
+    const to = value;
+    prevRef.current = value;
+    if (from === to) {
+      setDisplay(to);
+      return;
+    }
+    let raf;
+    const start = performance.now();
+    const tick = now => {
+      const t = Math.min(1, (now - start) / duration);
+      const eased = 1 - Math.pow(1 - t, 3); // cubic ease-out
+      setDisplay(from + (to - from) * eased);
+      if (t < 1) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [value, duration]);
+  return display;
+}
+
+// ---------- 组件 ----------
+
+export default function KatagoBoard() {
+  const [moves, setMoves] = useState([]);
+  const [phase, setPhase] = useState("user"); // user | thinking | error | over
+  const [userColor, setUserColor] = useState("B");
+  const [analysis, setAnalysis] = useState(null); // { aiWinrate, scoreLead, top[] }
+  const [result, setResult] = useState(null); // { winner, delta, via }
+  const [hint, setHint] = useState(null);
+  const [hover, setHover] = useState(null);
+  const [error, setError] = useState(null);
+  const [zen, setZen] = useState(false);
+
+  const movesRef = useRef(moves);
+  const userColorRef = useRef(userColor);
+  const abortRef = useRef(null);
+  const svgRef = useRef(null);
+  const hintTimerRef = useRef(null);
+
+  // 禅模式：Esc 退出
+  useEffect(() => {
+    if (!zen) return;
+    const onKey = e => {
+      if (e.key === "Escape") setZen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [zen]);
+
+  const commitMoves = useCallback(next => {
+    movesRef.current = next;
+    setMoves(next);
+  }, []);
+
+  const st = useMemo(() => buildState(moves), [moves]);
+  const { board, posKeys, captured, lastMove } = st;
+  const aiColor = userColor === "B" ? "W" : "B";
+  const turn = moves.length % 2 === 0 ? "B" : "W";
+  const isUserTurn = phase === "user" && turn === userColor;
+  const gameOver = phase === "over";
+
+  // AI 胜率（analysis.aiWinrate 为 AI 视角），数字与进度条同步动画
+  const aiWinrate = analysis?.aiWinrate ?? null;
+  const animatedWinrate = useAnimatedValue(aiWinrate ?? 0);
+  const shownWinrate = aiWinrate == null ? null : animatedWinrate;
+
+  const analyze = useCallback(async (movesList, signal) => {
+    const body = {
+      moves: movesList.map(m => (m.pass ? [m.color, "pass"] : [m.color, xyToCoord(m.x, m.y)])),
+      komi: 7.5,
+      rules: "chinese",
+      boardXSize: 19,
+      boardYSize: 19,
+      maxVisits: MAX_VISITS,
+      includeOwnership: false,
+      includePolicy: false,
+    };
+    const res = await fetch(API, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal,
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return res.json();
+  }, []);
+
+  const showHint = useCallback(text => {
+    setHint(text);
+    clearTimeout(hintTimerRef.current);
+    hintTimerRef.current = setTimeout(() => setHint(null), 1400);
+  }, []);
+
+  /** 对局结束：双弃权时用最后一次分析估算胜负 */
+  const finishGame = useCallback(
+    async finalMoves => {
+      setPhase("over");
+      const ctrl = new AbortController();
+      abortRef.current = ctrl;
+      const timeout = setTimeout(() => ctrl.abort(), REQUEST_TIMEOUT);
+      try {
+        const data = await analyze(finalMoves, ctrl.signal);
+        const root = data.rootInfo || {};
+        const lead = root.scoreLead;
+        if (lead == null) {
+          setResult({ winner: null, delta: null, via: "score-failed" });
+        } else {
+          const blackLead = root.currentPlayer === "B" ? lead : -lead;
+          setResult({
+            winner: blackLead > 0 ? "B" : "W",
+            delta: Math.abs(blackLead),
+            via: "score",
+          });
+        }
+      } catch {
+        setResult({ winner: null, delta: null, via: "score-failed" });
+      } finally {
+        clearTimeout(timeout);
+      }
+    },
+    [analyze],
+  );
+
+  /** AI 行棋：提交完整序列 → 取最佳应手 → 落子或弃权 */
+  const runAI = useCallback(async () => {
+    const ms = movesRef.current;
+    const uc = userColorRef.current;
+    const turn = ms.length % 2 === 0 ? "B" : "W";
+    if (turn !== (uc === "B" ? "W" : "B")) return; // 非 AI 回合
+
+    setPhase("thinking");
+    setError(null);
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
+    const timeout = setTimeout(() => ctrl.abort(), REQUEST_TIMEOUT);
+    try {
+      const data = await analyze(ms, ctrl.signal);
+      const infos = (data.moveInfos || []).filter(
+        info => info && typeof info.moveCoord === "string",
+      );
+      const ai = uc === "B" ? "W" : "B";
+      let chosen = null;
+      for (const info of infos) {
+        const xy = coordToXY(info.moveCoord);
+        if (!xy) continue;
+        const s = buildState(ms);
+        if (isLegal(s.board, xy.y * N + xy.x, ai === "B" ? 1 : 2, s.posKeys)) {
+          chosen = { info, xy };
+          break;
+        }
+      }
+      const root = data.rootInfo || {};
+      setAnalysis({ aiWinrate: root.winrate ?? null });
+
+      const next = chosen
+        ? [...ms, { color: ai, x: chosen.xy.x, y: chosen.xy.y }]
+        : [...ms, { color: ai, pass: true }];
+      commitMoves(next);
+      const lastTwo = next.slice(-2);
+      if (lastTwo.length === 2 && lastTwo.every(m => m.pass)) {
+        finishGame(next);
+      } else {
+        setPhase("user");
+      }
+    } catch (e) {
+      if (e.name === "AbortError") return; // 被悔棋/新局取消
+      setError("AI 分析失败（服务繁忙），可重试或让 AI 弃权");
+      setPhase("error");
+    } finally {
+      clearTimeout(timeout);
+    }
+  }, [analyze, finishGame, commitMoves]);
+
+  /** 用户落子 */
+  const play = useCallback(
+    (x, y) => {
+      if (!isUserTurn) return;
+      const idx = y * N + x;
+      if (board[idx] !== 0) return;
+      if (!isLegal(board, idx, userColor === "B" ? 1 : 2, posKeys)) {
+        showHint("此处不能落子");
+        return;
+      }
+      const next = [...movesRef.current, { color: userColor, x, y }];
+      commitMoves(next);
+      const lastTwo = next.slice(-2);
+      if (lastTwo.length === 2 && lastTwo.every(m => m.pass)) {
+        finishGame(next);
+        return;
+      }
+      setPhase("thinking");
+      runAI();
+    },
+    [board, posKeys, userColor, isUserTurn, runAI, finishGame, showHint, commitMoves],
+  );
+
+  /** 悔棋：撤销直到轮到自己（至少撤一手） */
+  const undo = useCallback(() => {
+    if (gameOver) return;
+    const ms = [...movesRef.current];
+    const target = userColor === "B" ? 0 : 1;
+    do {
+      ms.pop();
+    } while (ms.length > 0 && ms.length % 2 !== target);
+    abortRef.current?.abort();
+    abortRef.current = null;
+    commitMoves(ms);
+    setPhase("user");
+    setError(null);
+    setAnalysis(null);
+    setResult(null);
+  }, [gameOver, userColor, commitMoves]);
+
+  /** 用户弃权 */
+  const pass = useCallback(() => {
+    if (!isUserTurn) return;
+    const next = [...movesRef.current, { color: userColor, pass: true }];
+    commitMoves(next);
+    const lastTwo = next.slice(-2);
+    if (lastTwo.length === 2 && lastTwo.every(m => m.pass)) {
+      finishGame(next);
+      return;
+    }
+    setPhase("thinking");
+    runAI();
+  }, [isUserTurn, userColor, runAI, finishGame, commitMoves]);
+
+  /** 新局 / 换执 */
+  const newGame = useCallback(
+    color => {
+      abortRef.current?.abort();
+      abortRef.current = null;
+      userColorRef.current = color;
+      setUserColor(color);
+      commitMoves([]);
+      setPhase("user");
+      setError(null);
+      setAnalysis(null);
+      setResult(null);
+      setHint(null);
+      if (color === "W") runAI(); // 执白：AI 执黑先手
+    },
+    [runAI, commitMoves],
+  );
+
+  const resign = useCallback(() => {
+    if (gameOver) return;
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setPhase("over");
+    setResult({ winner: aiColor, via: "resign" });
+  }, [gameOver, aiColor]);
+
+  // ---------- 渲染 ----------
+
+  const toSvg = (x, y) => ({ cx: M + x * CELL, cy: M + y * CELL });
+
+  const onPointer = e => {
+    if (!svgRef.current) return null;
+    const rect = svgRef.current.getBoundingClientRect();
+    const px = ((e.clientX - rect.left) / rect.width) * S;
+    const py = ((e.clientY - rect.top) / rect.height) * S;
+    const x = Math.round((px - M) / CELL);
+    const y = Math.round((py - M) / CELL);
+    if (x < 0 || x >= N || y < 0 || y >= N) return null;
+    if (Math.abs(px - (M + x * CELL)) > CELL * 0.62) return null;
+    if (Math.abs(py - (M + y * CELL)) > CELL * 0.62) return null;
+    return { x, y };
+  };
+
+  const statusText = gameOver
+    ? result?.via === "resign"
+      ? "你认输了"
+      : "对局结束"
+    : phase === "error"
+      ? error
+      : `轮到${turn === "B" ? "黑" : "白"}棋${turn === userColor ? "（你）" : ""}`;
+
+  const resultText = result
+    ? result.via === "resign"
+      ? `${result.winner === "B" ? "黑" : "白"}方获胜（认输）`
+      : result.via === "score"
+        ? `${result.winner === "B" ? "黑" : "白"}方胜 ${result.delta.toFixed(1)} 目`
+        : "双方弃权，无法获取目差"
+    : null;
+
+  return (
+    <div
+      className={`not-prose ${
+        zen
+          ? "fixed inset-0 z-50 flex items-center justify-center bg-white dark:bg-zinc-900"
+          : "my-8"
+      }`}
+    >
+      {/* 状态栏（固定宽度槽位，避免切换时布局抖动导致棋盘位移） */}
+      <div
+        className={
+          zen
+            ? "hidden"
+            : "mb-4 flex flex-wrap items-center justify-center gap-x-6 gap-y-1 text-sm text-zinc-600 dark:text-zinc-400"
+        }
+      >
+        <div className="flex w-16 shrink-0 items-center justify-center">
+          {phase === "thinking" && (
+            <span className="flex items-center gap-1" aria-label="AI 思考中">
+              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-zinc-500 dark:bg-zinc-400" />
+              <span
+                className="h-1.5 w-1.5 animate-pulse rounded-full bg-zinc-500 dark:bg-zinc-400"
+                style={{ animationDelay: "180ms" }}
+              />
+              <span
+                className="h-1.5 w-1.5 animate-pulse rounded-full bg-zinc-500 dark:bg-zinc-400"
+                style={{ animationDelay: "360ms" }}
+              />
+            </span>
+          )}
+        </div>
+        <span className={`w-36 shrink-0 text-center ${hint ? "text-red-500" : ""}`}>
+          {hint || statusText}
+        </span>
+        <div className="w-44 shrink-0 text-center text-xs tabular-nums">
+          {captured.B + captured.W > 0 && `提子 黑 ${captured.B} · 白 ${captured.W} ｜ `}
+          手数 {moves.length}
+        </div>
+      </div>
+
+      {/* 棋盘 */}
+      <div
+        className={
+          zen ? "w-full max-w-[min(92vw,92vh)] px-4 sm:px-0" : "relative mx-auto max-w-[720px]"
+        }
+      >
+        <svg
+          ref={svgRef}
+          viewBox={`0 0 ${S} ${S}`}
+          className={`${styles.goBoard} h-auto w-full select-none rounded-lg shadow-sm ring-1 ring-zinc-200 dark:ring-zinc-800`}
+          style={{ backgroundColor: "var(--go-board-bg)" }}
+          onClick={e => {
+            const p = onPointer(e);
+            if (p) play(p.x, p.y);
+          }}
+          onMouseMove={e => {
+            const p = onPointer(e);
+            setHover(isUserTurn && p && board[p.y * N + p.x] === 0 ? p : null);
+          }}
+          onMouseLeave={() => setHover(null)}
+        >
+          {/* 网格线 */}
+          {Array.from({ length: N }, (_, k) => (
+            <g key={k}>
+              <line
+                x1={M + k * CELL}
+                y1={M}
+                x2={M + k * CELL}
+                y2={M + (N - 1) * CELL}
+                style={{ stroke: "var(--go-line)" }}
+                strokeWidth="1"
+              />
+              <line
+                x1={M}
+                y1={M + k * CELL}
+                x2={M + (N - 1) * CELL}
+                y2={M + k * CELL}
+                style={{ stroke: "var(--go-line)" }}
+                strokeWidth="1"
+              />
+            </g>
+          ))}
+          {/* 星位 */}
+          {STAR.flatMap(a => STAR.map(b => ({ a, b }))).map(({ a, b }, i) => (
+            <circle
+              key={i}
+              cx={M + a * CELL}
+              cy={M + b * CELL}
+              r="3.2"
+              style={{ fill: "var(--go-line)" }}
+            />
+          ))}
+          {/* 棋子 */}
+          {board.map((v, i) => {
+            if (!v) return null;
+            const x = i % N;
+            const y = (i / N) | 0;
+            const { cx, cy } = toSvg(x, y);
+            return (
+              <g key={i}>
+                <circle
+                  cx={cx}
+                  cy={cy}
+                  r={CELL * 0.46}
+                  style={{
+                    fill: v === 1 ? "var(--go-black-fill)" : "var(--go-white-fill)",
+                    stroke: v === 1 ? "var(--go-black-edge)" : "var(--go-white-edge)",
+                  }}
+                  strokeWidth="1"
+                />
+                {lastMove && lastMove.x === x && lastMove.y === y && (
+                  <circle
+                    cx={cx}
+                    cy={cy}
+                    r={CELL * 0.34}
+                    fill="none"
+                    strokeWidth={CELL * 0.09}
+                    style={{
+                      stroke: v === 1 ? "var(--go-mark-on-black)" : "var(--go-mark-on-white)",
+                    }}
+                  />
+                )}
+              </g>
+            );
+          })}
+          {/* 悬停预览（使用真实棋子颜色，仅以透明度区分预览） */}
+          {hover && (
+            <circle
+              cx={toSvg(hover.x, hover.y).cx}
+              cy={toSvg(hover.x, hover.y).cy}
+              r={CELL * 0.46}
+              strokeWidth="1"
+              style={{
+                fill: userColor === "B" ? "var(--go-black-fill)" : "var(--go-white-fill)",
+                stroke: userColor === "B" ? "var(--go-black-edge)" : "var(--go-white-edge)",
+                opacity: "var(--go-ghost-opacity)",
+              }}
+            />
+          )}
+        </svg>
+      </div>
+
+      {/* 分析信息 */}
+      {!zen && (analysis || (gameOver && resultText) || phase === "error") && (
+        <div className="mx-auto mt-4 max-w-[720px] text-sm text-zinc-600 dark:text-zinc-400">
+          {analysis ? (
+            <div className="flex flex-col gap-1.5 text-xs tabular-nums">
+              <div className="flex items-center gap-2">
+                <span className="w-7 shrink-0">AI</span>
+                <div className="h-2 flex-1 overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-800">
+                  <div
+                    className="h-full rounded-full bg-zinc-900 transition-[width] duration-700 ease-out dark:bg-zinc-500"
+                    style={{
+                      width: `${Math.max(0, Math.min(100, (shownWinrate ?? 0) * 100))}%`,
+                    }}
+                  />
+                </div>
+                <span className="w-11 shrink-0 text-right">{pct(shownWinrate)}</span>
+              </div>
+            </div>
+          ) : null}
+          {gameOver && resultText && (
+            <div className="mt-3 rounded-md border border-zinc-200 px-3 py-2 dark:border-zinc-800">
+              {resultText}
+            </div>
+          )}
+          {phase === "error" && (
+            <div className="mt-3 flex items-center gap-2">
+              <button
+                className="rounded-md border border-zinc-300 px-3 py-1 text-xs hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+                onClick={() => {
+                  setPhase("thinking");
+                  runAI();
+                }}
+              >
+                重试
+              </button>
+              <button
+                className="rounded-md border border-zinc-300 px-3 py-1 text-xs hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+                onClick={() => {
+                  const next = [...movesRef.current, { color: aiColor, pass: true }];
+                  commitMoves(next);
+                  const lastTwo = next.slice(-2);
+                  if (lastTwo.length === 2 && lastTwo.every(m => m.pass)) {
+                    finishGame(next);
+                  } else {
+                    setPhase("user");
+                  }
+                }}
+              >
+                AI 弃权
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* 操作 */}
+      <div
+        className={
+          zen
+            ? "hidden"
+            : "mx-auto mt-4 flex max-w-[720px] flex-wrap items-center justify-center gap-2 text-xs"
+        }
+      >
+        {/* 执黑 / 执白 */}
+        <div className="flex items-center rounded-full border border-zinc-200 p-0.5 dark:border-zinc-800">
+          {["B", "W"].map(c => (
+            <button
+              key={c}
+              onClick={() => newGame(c)}
+              title={c === "B" ? "执黑先手" : "执白后手"}
+              className={`rounded-full px-4 py-1 transition-colors duration-150 ${
+                userColor === c
+                  ? "bg-zinc-900 text-zinc-50 dark:bg-zinc-100 dark:text-zinc-900"
+                  : "text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
+              }`}
+            >
+              {c === "B" ? "执黑" : "执白"}
+            </button>
+          ))}
+        </div>
+
+        {/* 悔棋 / 弃权 / 认输（对局结束时为「再来一局」） */}
+        <div className="flex items-center rounded-full border border-zinc-200 p-0.5 dark:border-zinc-800">
+          <button
+            onClick={undo}
+            disabled={gameOver || moves.length === 0}
+            title="悔棋：撤销直到轮到你"
+            className="rounded-full px-4 py-1 text-zinc-500 transition-colors duration-150 hover:bg-zinc-100 hover:text-zinc-900 disabled:pointer-events-none disabled:opacity-30 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
+          >
+            悔棋
+          </button>
+          <button
+            onClick={pass}
+            disabled={!isUserTurn}
+            title="弃权"
+            className="rounded-full px-4 py-1 text-zinc-500 transition-colors duration-150 hover:bg-zinc-100 hover:text-zinc-900 disabled:pointer-events-none disabled:opacity-30 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
+          >
+            弃权
+          </button>
+          <button
+            onClick={gameOver ? () => newGame(userColor) : resign}
+            disabled={gameOver ? false : phase === "error"}
+            title={gameOver ? "再来一局" : "认输"}
+            className={`rounded-full px-4 py-1 transition-colors duration-150 disabled:pointer-events-none disabled:opacity-30 ${
+              gameOver
+                ? "bg-zinc-900 text-zinc-50 hover:opacity-80 dark:bg-zinc-100 dark:text-zinc-900"
+                : "text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
+            }`}
+          >
+            {gameOver ? "再来一局" : "认输"}
+          </button>
+        </div>
+
+        {/* 禅 */}
+        <div className="flex items-center rounded-full border border-zinc-200 p-0.5 dark:border-zinc-800">
+          <button
+            onClick={() => setZen(true)}
+            title="禅模式：只显示棋盘（Esc 退出）"
+            className="rounded-full px-4 py-1 text-zinc-500 transition-colors duration-150 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
+          >
+            禅
+          </button>
+        </div>
+      </div>
+
+      {/* 禅模式退出（悬浮于棋盘右上角） */}
+      {zen && (
+        <button
+          onClick={() => setZen(false)}
+          title="退出禅模式 (Esc)"
+          className="absolute right-4 top-4 rounded-full px-3 py-1 text-xs text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-500 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
+        >
+          X
+        </button>
+      )}
+    </div>
+  );
+}

--- a/components/katago-board.module.css
+++ b/components/katago-board.module.css
@@ -1,0 +1,24 @@
+/* KataGo 对弈棋盘配色（CSS Module，仅随组件加载） */
+.goBoard {
+  --go-board-bg: #f5f4f0;
+  --go-line: #9c9a91;
+  --go-black-fill: #18181b;
+  --go-black-edge: #3f3f46;
+  --go-white-fill: #fafafa;
+  --go-white-edge: #a1a1aa;
+  --go-mark-on-black: #fafafa;
+  --go-mark-on-white: #18181b;
+  --go-ghost-opacity: 0.4;
+}
+
+:global(html.dark) .goBoard {
+  --go-board-bg: #171614;
+  --go-line: #52525b;
+  --go-black-fill: #1e1e21;
+  --go-black-edge: #71717a;
+  --go-white-fill: #d4d4d8;
+  --go-white-edge: #71717a;
+  --go-mark-on-black: #d4d4d8;
+  --go-mark-on-white: #1e1e21;
+  --go-ghost-opacity: 0.7;
+}

--- a/lib/go-rules.js
+++ b/lib/go-rules.js
@@ -1,0 +1,109 @@
+/**
+ * 19x19 围棋规则引擎（纯函数，无 React 依赖，可独立测试）。
+ * 用于 katago 对弈页：在浏览器端维护棋局状态，配合无状态分析接口使用。
+ */
+
+export const N = 19;
+export const LETTERS = "ABCDEFGHJKLMNOPQRST"; // 19 列，跳过 I
+
+const neighborsOf = i => {
+  const x = i % N;
+  const y = (i / N) | 0;
+  const out = [];
+  if (x > 0) out.push(i - 1);
+  if (x < N - 1) out.push(i + 1);
+  if (y > 0) out.push(i - N);
+  if (y < N - 1) out.push(i + N);
+  return out;
+};
+
+const groupInfo = (board, start) => {
+  const color = board[start];
+  const group = [start];
+  const seen = new Set([start]);
+  const liberties = new Set();
+  const stack = [start];
+  while (stack.length) {
+    const i = stack.pop();
+    for (const nb of neighborsOf(i)) {
+      if (board[nb] === 0) liberties.add(nb);
+      else if (board[nb] === color && !seen.has(nb)) {
+        seen.add(nb);
+        group.push(nb);
+        stack.push(nb);
+      }
+    }
+  }
+  return { group, liberties };
+};
+
+/** 模拟在 i 处落 color 子（1=黑 2=白），返回新棋盘与提子数（不校验合法性） */
+const simulatePlace = (board, i, color) => {
+  const b = board.slice();
+  b[i] = color;
+  const opp = color === 1 ? 2 : 1;
+  let captured = 0;
+  for (const nb of neighborsOf(i)) {
+    if (b[nb] === opp) {
+      const { group, liberties } = groupInfo(b, nb);
+      if (liberties.size === 0) {
+        for (const g of group) b[g] = 0;
+        captured += group.length;
+      }
+    }
+  }
+  return { board: b, captured };
+};
+
+/**
+ * 由落子序列重建棋盘状态。
+ * moves: [{ color: 'B'|'W', x, y } | { color, pass: true }]
+ * 返回 { board, posKeys, captured, lastMove }
+ */
+export const buildState = moves => {
+  let board = new Array(N * N).fill(0);
+  let posKeys = new Set([board.join("")]);
+  const captured = { B: 0, W: 0 };
+  let lastMove = null;
+  for (const m of moves) {
+    if (m.pass) {
+      // 弃权后清除禁着点记忆（简单劫规则重置）
+      posKeys = new Set([board.join("")]);
+      lastMove = null;
+      continue;
+    }
+    const color = m.color === "B" ? 1 : 2;
+    const res = simulatePlace(board, m.y * N + m.x, color);
+    board = res.board;
+    captured[m.color] += res.captured;
+    posKeys.add(board.join(""));
+    lastMove = { x: m.x, y: m.y, color: m.color };
+  }
+  return { board, posKeys, captured, lastMove };
+};
+
+/** 落子是否合法：空点、非自杀、不重复历史局面（位置超劫） */
+export const isLegal = (board, i, color, posKeys) => {
+  if (board[i] !== 0) return false;
+  const { board: b, captured } = simulatePlace(board, i, color);
+  if (captured === 0) {
+    const own = groupInfo(b, i);
+    if (own.liberties.size === 0) return false; // 自杀
+  }
+  if (posKeys.has(b.join(""))) return false; // 劫 / 循环
+  return true;
+};
+
+/** 坐标转换：API 坐标（如 "Q3"、"pass"）<-> 棋盘索引 */
+export const coordToXY = coord => {
+  if (!coord || typeof coord !== "string") return null;
+  if (/^pass$/i.test(coord)) return null; // pass 由调用方单独处理
+  const m = coord.match(/^([A-Za-z])(\d{1,2})$/);
+  if (!m) return null;
+  const x = LETTERS.indexOf(m[1].toUpperCase());
+  const row = parseInt(m[2], 10);
+  if (x < 0 || row < 1 || row > N) return null;
+  return { x, y: N - row };
+};
+
+export const xyToCoord = (x, y) => `${LETTERS[x]}${N - y}`;

--- a/pages/blog/katago.js
+++ b/pages/blog/katago.js
@@ -5,7 +5,7 @@ import cfg from "../../lib/config.mjs";
 const KatagoBoard = dynamic(() => import("../../components/katago-board"), {
   ssr: true,
   loading: () => (
-    <div className="mx-auto my-8 aspect-square max-w-[720px] animate-pulse rounded-lg bg-zinc-100 dark:bg-zinc-900" />
+    <div className="mx-auto my-8 aspect-square max-w-180 animate-pulse rounded-lg bg-zinc-100 dark:bg-zinc-900" />
   ),
 });
 

--- a/pages/blog/katago.js
+++ b/pages/blog/katago.js
@@ -1,0 +1,29 @@
+import dynamic from "next/dynamic";
+import Blog from "../../components/blog";
+import cfg from "../../lib/config.mjs";
+
+const KatagoBoard = dynamic(() => import("../../components/katago-board"), {
+  ssr: true,
+  loading: () => (
+    <div className="mx-auto my-8 aspect-square max-w-[720px] animate-pulse rounded-lg bg-zinc-100 dark:bg-zinc-900" />
+  ),
+});
+
+export const blogProps = {
+  author: cfg.authorName,
+  title: "与 KataGo 对弈",
+  description: "与 AI 实时对弈一局围棋",
+  date: "2026-08-21",
+  locale: "zh",
+  tags: "go, game, ai",
+  visible: true,
+};
+
+export default function Katago() {
+  return (
+    <Blog {...blogProps} noReply>
+      <p>中国规则，贴 7 目半。</p>
+      <KatagoBoard />
+    </Blog>
+  );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增在线围棋对弈页面，支持用户与 AI 进行对局。
  * 支持落子、弃权、认输、悔棋、重新开局及黑白方切换。
  * 提供落子预览、提子显示、手数统计、胜率动画和禅模式。
  * 新增 19×19 棋盘规则校验，支持非法着法、自杀和重复局面提示。
  * AI 分析失败或请求超时时支持取消、重试并显示结果提示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->